### PR TITLE
Email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # parse-server-simple-mailgun-adapter
 Used to send Parse Server password reset and email verification emails though Mailgun
+
+
+## How to use
+```
+var server = ParseServer({
+  ...
+  emailAdapter: {
+    module: 'parse-server-simple-mailgun-adapter',
+    options: {
+      // The address that your emails come from
+      fromAddress: 'no-reply@yourdomain.com',
+      // Your domain from mailgun.com
+      domain: 'mg.yourdomain.com',
+      // Your API key from mailgun.com
+      apiKey: 'key-0123456789abcdefghijklmnopqrstuv',
+      // Verification email subject
+      verificationSubject: 'Please verify your e-mail for %appname%',
+      // Verification email body
+      verificationBody: 'Hi,\n\nYou are being asked to confirm the e-mail address %email% with %appname%\n\nClick here to confirm it:\n%link%',
+      // Password reset email subject
+      passwordResetSubject: 'Password Reset Request for %appname%',
+      // Password reset email body
+      passwordResetBody: 'Hi,\n\nYou requested a password reset for %appname%.\n\nClick here to reset it:\n%link%'
+    }
+  }
+  ...
+});
+```
+
+## Variables 
+
+Customize the e-mail sent to your users when they reset their password or when we verify their email address. The following variables will be automatically filled in with their appropriate values:
+
+`%username%` the user's display name
+
+`%email%` the user's email address
+
+`%appname%` your application's display name
+
+`%link%` the link the user must click to perform the requested action

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var SimpleMailgunAdapter = mailgunOptions => {
 
   var mailgun = Mailgun(mailgunOptions);
 
-  function fillVariables(text) {
+  function fillVariables(text, options) {
     text = text.replace("%username%", options.user.get("username"));
     text = text.replace("%email%", options.user.get("email"));
     text = text.replace("%appname%", options.appName);
@@ -37,7 +37,7 @@ var SimpleMailgunAdapter = mailgunOptions => {
       from: mailgunOptions.fromAddress,
       to: options.user.get("email"),
       subject: mailgunOptions.verificationSubject,
-      text: fillVariables(mailgunOptions.verificationBody)
+      text: fillVariables(mailgunOptions.verificationBody, options)
     }
     return new Promise((resolve, reject) => {
       mailgun.messages().send(data, (err, body) => {
@@ -54,7 +54,7 @@ var SimpleMailgunAdapter = mailgunOptions => {
       from: mailgunOptions.fromAddress,
       to: options.user.get("email"),
       subject: mailgunOptions.passwordResetSubject,
-      text: fillVariables(mailgunOptions.passwordResetBody)
+      text: fillVariables(mailgunOptions.passwordResetBody, options)
     }
     return new Promise((resolve, reject) => {
       mailgun.messages().send(data, (err, body) => {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,66 @@ var SimpleMailgunAdapter = mailgunOptions => {
   if (!mailgunOptions || !mailgunOptions.apiKey || !mailgunOptions.domain || !mailgunOptions.fromAddress) {
     throw 'SimpleMailgunAdapter requires an API Key, domain, and fromAddress.';
   }
+
+  mailgunOptions.verificationSubject =
+    mailgunOptions.verificationSubject ||
+    'Please verify your e-mail for %appname%';
+  mailgunOptions.verificationBody =
+    mailgunOptions.verificationBody ||
+    'Hi,\n\nYou are being asked to confirm the e-mail address %email% ' +
+    'with %appname%\n\nClick here to confirm it:\n%link%';
+  mailgunOptions.passwordResetSubject =
+    mailgunOptions.passwordResetSubject ||
+    'Password Reset Request for %appname%';
+  mailgunOptions.passwordResetBody =
+    mailgunOptions.passwordResetBody ||
+    'Hi,\n\nYou requested a password reset for %appname%.\n\nClick here ' +
+    'to reset it:\n%link%';
+
+
   var mailgun = Mailgun(mailgunOptions);
+
+  function fillVariables(text) {
+    text = text.replace("%username%", options.user.get("username"));
+    text = text.replace("%email%", options.user.get("email"));
+    text = text.replace("%appname%", options.appName);
+    text = text.replace("%link%", options.link);
+    return text;
+  }
+
+  var sendVerificationEmail = options => {
+    var message = {
+      from: mailgunOptions.fromAddress,
+      to: options.user.get("email"),
+      subject: mailgunOptions.verificationSubject,
+      text: fillVariables(mailgunOptions.verificationBody)
+    }
+    return new Promise((resolve, reject) => {
+      mailgun.messages().send(data, (err, body) => {
+        if (typeof err !== 'undefined') {
+          reject(err);
+        }
+        resolve(body);
+      });
+    });
+  }
+
+  var sendPasswordResetEmail = options => {
+    var message = {
+      from: mailgunOptions.fromAddress,
+      to: options.user.get("email"),
+      subject: mailgunOptions.passwordResetSubject,
+      text: fillVariables(mailgunOptions.passwordResetBody)
+    }
+    return new Promise((resolve, reject) => {
+      mailgun.messages().send(data, (err, body) => {
+        if (typeof err !== 'undefined') {
+          reject(err);
+        }
+        resolve(body);
+      });
+    });
+  }
 
   var sendMail = mail => {
     var data = {
@@ -26,6 +85,8 @@ var SimpleMailgunAdapter = mailgunOptions => {
   }
 
   return Object.freeze({
+    sendVerificationEmail: sendVerificationEmail,
+    sendPasswordResetEmail: sendPasswordResetEmail,
     sendMail: sendMail
   });
 }

--- a/index.js
+++ b/index.js
@@ -33,10 +33,10 @@ var SimpleMailgunAdapter = mailgunOptions => {
   }
 
   var sendVerificationEmail = options => {
-    var message = {
+    var data = {
       from: mailgunOptions.fromAddress,
       to: options.user.get("email"),
-      subject: mailgunOptions.verificationSubject,
+      subject: fillVariables(mailgunOptions.verificationSubject, options),
       text: fillVariables(mailgunOptions.verificationBody, options)
     }
     return new Promise((resolve, reject) => {
@@ -50,10 +50,10 @@ var SimpleMailgunAdapter = mailgunOptions => {
   }
 
   var sendPasswordResetEmail = options => {
-    var message = {
+    var data = {
       from: mailgunOptions.fromAddress,
       to: options.user.get("email"),
-      subject: mailgunOptions.passwordResetSubject,
+      subject: fillVariables(mailgunOptions.passwordResetSubject, options),
       text: fillVariables(mailgunOptions.passwordResetBody, options)
     }
     return new Promise((resolve, reject) => {
@@ -71,9 +71,8 @@ var SimpleMailgunAdapter = mailgunOptions => {
       from: mailgunOptions.fromAddress,
       to: mail.to,
       subject: mail.subject,
-      text: mail.text,
+      text: mail.text
     }
-
     return new Promise((resolve, reject) => {
       mailgun.messages().send(data, (err, body) => {
         if (typeof err !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@bcomeau/parse-server-simple-mailgun-adapter",
-  "version": "1.0.4",
+  "name": "parse-server-simple-mailgun-adapter",
+  "version": "1.0.1",
   "description": "Used to send Parse Server password reset and email verification emails though Mailgun",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bcomeau/parse-server-simple-mailgun-adapter.git"
+    "url": "git+https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter.git"
   },
   "keywords": [
     "parse",
@@ -18,12 +18,12 @@
   "author": "Drew Gross",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter/issues"
+    "url": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter/issues"
   },
   "contributors": [
     "Benjamin Comeau <benjamin@bcomeau.ca>"
-  ],
-  "homepage": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter#readme",
+    ],
+  "homepage": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter#readme",
   "dependencies": {
     "mailgun-js": "^0.7.7"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parse-server-simple-mailgun-adapter",
+  "name": "@bcomeau/parse-server-simple-mailgun-adapter",
   "version": "1.0.1",
   "description": "Used to send Parse Server password reset and email verification emails though Mailgun",
   "main": "index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter.git"
+    "url": "git+https://github.com/bcomeau/parse-server-simple-mailgun-adapter.git"
   },
   "keywords": [
     "parse",
@@ -18,14 +18,14 @@
   "author": "Drew Gross",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter/issues"
+    "url": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter/issues"
   },
   "contributors": [
    { "name" : "Benjamin Comeau"
     , "email" : "benjamin@bcomeau.ca"
    } 
   ],
-  "homepage": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter#readme",
+  "homepage": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter#readme",
   "dependencies": {
     "mailgun-js": "^0.7.7"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcomeau/parse-server-simple-mailgun-adapter",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "Used to send Parse Server password reset and email verification emails though Mailgun",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "parse-server-simple-mailgun-adapter",
-  "version": "1.0.1",
+  "name": "parse-server-mailgun-adapter-template",
+  "version": "1.1.1",
   "description": "Used to send Parse Server password reset and email verification emails though Mailgun",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter.git"
+    "url": "git+https://github.com/bcomeau/parse-server-simple-mailgun-adapter.git"
   },
   "keywords": [
     "parse",
@@ -18,12 +18,12 @@
   "author": "Drew Gross",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter/issues"
+    "url": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter/issues"
   },
   "contributors": [
     "Benjamin Comeau <benjamin@bcomeau.ca>"
     ],
-  "homepage": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter#readme",
+  "homepage": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter#readme",
   "dependencies": {
     "mailgun-js": "^0.7.7"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server-simple-mailgun-adapter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Used to send Parse Server password reset and email verification emails though Mailgun",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,11 @@
   "bugs": {
     "url": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter/issues"
   },
+  "contributors": [
+   { "name" : "Benjamin Comeau"
+    , "email" : "benjamin@bcomeau.ca"
+   } 
+  ],
   "homepage": "https://github.com/ParsePlatform/parse-server-simple-mailgun-adapter#readme",
   "dependencies": {
     "mailgun-js": "^0.7.7"

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "url": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter/issues"
   },
   "contributors": [
-   { "name" : "Benjamin Comeau"
-    , "email" : "benjamin@bcomeau.ca"
-   } 
+    "Benjamin Comeau <benjamin@bcomeau.ca>"
   ],
   "homepage": "https://github.com/bcomeau/parse-server-simple-mailgun-adapter#readme",
   "dependencies": {


### PR DESCRIPTION
## Add configuration for
- Verification email subject
- Verification email body
- Password reset email subject
- Password reset email body
## These variables can be used in the templates
- `%username%` the user's display name
- `%email%` the user's email address
- `%appname%` your application's display name
- `%link%` the link the user must click to perform the requested action
## Example

```
var server = ParseServer({
  ...
  emailAdapter: {
    module: 'parse-server-simple-mailgun-adapter',
    options: {
      // The address that your emails come from
      fromAddress: 'no-reply@yourdomain.com',
      // Your domain from mailgun.com
      domain: 'mg.yourdomain.com',
      // Your API key from mailgun.com
      apiKey: 'key-0123456789abcdefghijklmnopqrstuv',
      // Verification email subject
      verificationSubject: 'Please verify your e-mail for %appname%',
      // Verification email body
      verificationBody: 'Hi,\n\nYou are being asked to confirm the e-mail address %email% with %appname%\n\nClick here to confirm it:\n%link%',
      // Password reset email subject
      passwordResetSubject: 'Password Reset Request for %appname%',
      // Password reset email body
      passwordResetBody: 'Hi,\n\nYou requested a password reset for %appname%.\n\nClick here to reset it:\n%link%'
    }
  }
  ...
});
```
